### PR TITLE
Changed devcontainer to use dotnet v6 instead of latest to support BRM

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,6 @@
   "remoteUser": "vscode",
   "features": {
     "node": "latest",
-    "dotnet": "latest"
+    "dotnet": "6"
   }
 }


### PR DESCRIPTION
Latest is now dotnet 7 and BRM doesn't work with it.

#85 