### PR TITLE
Fixed readme table module version sort logic

### DIFF
--- a/scripts/github-actions/refresh-table.js
+++ b/scripts/github-actions/refresh-table.js
@@ -75,7 +75,7 @@ async function generateModulesTable(axios, fs, path, core) {
       const latestTag = tags
         .filter((tag) => tag.name.includes(module + "/"))
         .map((tag) => tag.name.split("/").pop())
-        .sort()
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric:true }))
         .pop();
       return latestTag;
     }


### PR DESCRIPTION
The table was incorrectly showing the highest module version
#92 