### PR TITLE
Increased GitHub Tag API Page Size

### DIFF
--- a/scripts/github-actions/refresh-table.js
+++ b/scripts/github-actions/refresh-table.js
@@ -30,7 +30,7 @@ function getSubdirNames(fs, dir) {
 async function generateModulesTable(axios, fs, path, core) {
   const tableData = [["Module", "Version", "Docs"]];
   const moduleGroups = getSubdirNames(fs, "bicep/modules");
-  const tagsUrl = "https://api.github.com/repos/azure/osdu-bicep/tags";
+  const tagsUrl = "https://api.github.com/repos/azure/osdu-bicep/tags?per_page=1000";
   const tagsResponse = await axios.get(tagsUrl);
   const tags = tagsResponse.data;
 


### PR DESCRIPTION
Discovered while fixing #93 
The GitHub api only returns 30 tags by default. You can either implement paging logic, or increase the page size. I opted to increase the page size for now.