### PR TITLE
Added delegatedManagedIdentityResourceId to role assignments in acr_import and aks_run_command

### DIFF
--- a/bicep/main.bicep
+++ b/bicep/main.bicep
@@ -644,6 +644,7 @@ module acrImport 'modules_private/acr_import.bicep' = if (!empty(serviceLayerCon
     acrName: registry.outputs.name
     location: location
     images: serviceLayerConfig.imageNames
+    crossTenant: crossTenant
   }
 }
 

--- a/bicep/modules_private/acr_import.bicep
+++ b/bicep/modules_private/acr_import.bicep
@@ -31,13 +31,16 @@ param images array
 @description('A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate')
 param initialScriptDelay string = '30s'
 
+@description('Optional. Indicates if the module is used in a cross tenant scenario')
+param crossTenant bool = false
+
 @allowed([
   'OnSuccess'
   'OnExpiration'
   'Always'
 ])
 @description('When the script resource is cleaned up')
-param cleanupPreference string = 'OnExpiration'
+param cleanupPreference string = 'OnSuccess'
 
 resource acr 'Microsoft.ContainerRegistry/registries@2021-12-01-preview' existing = {
   name: acrName
@@ -60,6 +63,7 @@ resource rbac 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = if 
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', rbacRoleNeeded)
     principalId: useExistingManagedIdentity ? existingDepScriptId.properties.principalId : newDepScriptId.properties.principalId
     principalType: 'ServicePrincipal'
+    delegatedManagedIdentityResourceId: crossTenant ? (useExistingManagedIdentity ? existingDepScriptId.id : newDepScriptId.id) : ''
   }
 }
 

--- a/bicep/modules_private/acr_import.bicep
+++ b/bicep/modules_private/acr_import.bicep
@@ -60,7 +60,7 @@ resource rbac 'Microsoft.Authorization/roleAssignments@2020-08-01-preview' = if 
     roleDefinitionId: resourceId('Microsoft.Authorization/roleDefinitions', rbacRoleNeeded)
     principalId: useExistingManagedIdentity ? existingDepScriptId.properties.principalId : newDepScriptId.properties.principalId
     principalType: 'ServicePrincipal'
-    delegatedManagedIdentityResourceId: crossTenant ? (useExistingManagedIdentity ? existingDepScriptId.id : newDepScriptId.id) : ''
+    delegatedManagedIdentityResourceId: crossTenant ? (useExistingManagedIdentity ? existingDepScriptId.id : newDepScriptId.id) : null
   }
 }
 

--- a/bicep/modules_private/acr_import.bicep
+++ b/bicep/modules_private/acr_import.bicep
@@ -116,7 +116,6 @@ resource createImportImage 'Microsoft.Resources/deploymentScripts@2020-10-01' = 
       until [ $retryLoopCount -ge $retryMax ]
       do
         echo "Importing Image: $imageName into ACR: $acrName"
-        echo "Sub: $subscription"
         az acr import -n $acrName --source $imageName --force 2>&1 \
           && break
         sleep $retrySleep

--- a/bicep/modules_private/aks_run_command.bicep
+++ b/bicep/modules_private/aks_run_command.bicep
@@ -31,6 +31,9 @@ param commands array
 @description('A delay before the script import operation starts. Primarily to allow Azure AAD Role Assignments to propagate')
 param initialScriptDelay string = '120s'
 
+@description('Optional. Indicates if the module is used in a cross tenant scenario')
+param crossTenant bool = false
+
 @allowed([
   'OnSuccess'
   'OnExpiration'
@@ -60,6 +63,7 @@ resource rbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for roleDe
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleDefId)
     principalId: useExistingManagedIdentity ? existingDepScriptId.properties.principalId : newDepScriptId.properties.principalId
     principalType: 'ServicePrincipal'
+    delegatedManagedIdentityResourceId: crossTenant ? (useExistingManagedIdentity ? existingDepScriptId.id : newDepScriptId.id) : null
   }
 }]
 

--- a/bicep/modules_private/aks_run_command.bicep
+++ b/bicep/modules_private/aks_run_command.bicep
@@ -123,7 +123,7 @@ resource runAksCommand 'Microsoft.Resources/deploymentScripts@2020-10-01' = [for
       fi
 
       echo "Sending command $command to AKS Cluster $aksName in $RG"
-      cmdOut=$(az aks command invoke -g $RG -n $aksName -o json --command "${command}")
+      cmdOut=$(az aks command invoke -g $RG -n $aksName -o json --command "${command}" 2>&1)
       echo $cmdOut
 
       jsonOutputString=$cmdOut

--- a/bicep/modules_private/helm_install.bicep
+++ b/bicep/modules_private/helm_install.bicep
@@ -13,6 +13,9 @@ param location string = resourceGroup().location
 @description('The namespace for the chart.')
 param namespace string = 'cert-manager'
 
+@description('Optional. Indicates if the module is used in a cross tenant scenario')
+param crossTenant bool = false
+
 var contributor='b24988ac-6180-42a0-ab88-20f7382dd24c'
 var rbacClusterAdmin='b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
 
@@ -36,6 +39,7 @@ module aksRun './aks_run_command.bicep' = {
     commands: [
       formattedHelmCommands
     ]
+    crossTenant: crossTenant
   }
 }
 

--- a/bicep/modules_private/helm_workload_id.bicep
+++ b/bicep/modules_private/helm_workload_id.bicep
@@ -16,6 +16,9 @@ param tenantId string = subscription().tenantId
 @description('The namespace for the chart.')
 param namespace string = 'azure-workload-identity-system'
 
+@description('Optional. Indicates if the module is used in a cross tenant scenario')
+param crossTenant bool = false
+
 var contributor='b24988ac-6180-42a0-ab88-20f7382dd24c'
 var rbacClusterAdmin='b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
 
@@ -39,6 +42,7 @@ module aksRun './aks_run_command.bicep' = {
     commands: [
       formattedHelmCommands
     ]
+    crossTenant: crossTenant
   }
 }
 


### PR DESCRIPTION
When assigning roles, in a cross-tenant scenario, you need to set delegatedManagedIdentityResourceId to the ID of the managed identity.